### PR TITLE
feat: modularize into monorepo with Effect layers and HTTP recording

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,33 +22,11 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  examples/github-sdk-example:
-    dependencies:
-      '@akoenig/effect-github':
-        specifier: workspace:*
-        version: link:../../packages/github
-      '@akoenig/effect-http-recorder':
-        specifier: workspace:*
-        version: link:../../packages/http-recorder
-      '@effect/platform':
-        specifier: ^0.87.6
-        version: 0.87.6(effect@3.16.12)
-      '@effect/platform-node':
-        specifier: ^0.88.10
-        version: 0.88.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
-      effect:
-        specifier: ^3.16.12
-        version: 3.16.12
-    devDependencies:
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-
   packages/github:
     dependencies:
       '@effect/platform':
         specifier: ^0.87.6
-        version: 0.87.6(effect@3.16.12)
+        version: 0.87.7(effect@3.16.12)
       effect:
         specifier: ^3.16.12
         version: 3.16.12
@@ -58,26 +36,26 @@ importers:
         version: link:../http-recorder
       '@effect/platform-node':
         specifier: ^0.88.10
-        version: 0.88.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+        version: 0.88.11(@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
 
   packages/http-recorder:
     dependencies:
       '@effect/platform':
         specifier: ^0.87.6
-        version: 0.87.6(effect@3.16.12)
+        version: 0.87.7(effect@3.16.12)
       effect:
         specifier: ^3.16.12
         version: 3.16.12
     devDependencies:
       '@effect/platform-node':
         specifier: ^0.88.10
-        version: 0.88.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+        version: 0.88.11(@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       '@effect/vitest':
         specifier: ^0.23.12
-        version: 0.23.12(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0)(tsx@4.20.3))
+        version: 0.23.12(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.16.0)(tsx@4.20.3)
+        version: 3.2.4(@types/node@22.16.0)
 
 packages:
 
@@ -193,19 +171,19 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@effect/cluster@0.41.10':
-    resolution: {integrity: sha512-RD7TIZ/Y0vq5WXOqgEwS/5pm1TTZOjxxNU1h2o/UJ1OKDPF5DsSdfd3C5aqPfLAV3V+GxL43S8NucR7BQqiwtw==}
+  '@effect/cluster@0.41.11':
+    resolution: {integrity: sha512-5Rpm5X85NfHcrDPgZESY0WnkDr7fSmA1CTZVJFs3su9kkoMWepsNqBi9bzmNRRz2fCVnZapJx0chry6YAQCJNg==}
     peerDependencies:
-      '@effect/platform': ^0.87.6
-      '@effect/rpc': ^0.64.7
-      '@effect/sql': ^0.40.7
-      '@effect/workflow': ^0.4.7
+      '@effect/platform': ^0.87.7
+      '@effect/rpc': ^0.64.8
+      '@effect/sql': ^0.40.8
+      '@effect/workflow': ^0.4.8
       effect: ^3.16.12
 
-  '@effect/experimental@0.51.7':
-    resolution: {integrity: sha512-Vlykyd5XvwN0Y5i49ubX1rmapR0fYfdkkIzgqcVZzzmMPVo/xp5PmdQOOPBg6QkmH4P0eFMHw3IYLgFqJziE/w==}
+  '@effect/experimental@0.51.8':
+    resolution: {integrity: sha512-eXZhuW60d1jQHmp1tVRfNLoIKHa0sGC4jmc52OO8E4gqUvW4dQky6+2YheOveVLC6lhLTXjGc370w1c3HEYIpg==}
     peerDependencies:
-      '@effect/platform': ^0.87.6
+      '@effect/platform': ^0.87.7
       effect: ^3.16.12
       ioredis: ^5
       lmdb: ^3
@@ -215,40 +193,40 @@ packages:
       lmdb:
         optional: true
 
-  '@effect/platform-node-shared@0.42.10':
-    resolution: {integrity: sha512-HhexkcGxw8yEjHbOqKqVVJzjbpkZViWkc9jKrj+v1II9Yam/ujjk+AiaodbG4VB/ppjSHSryaJCWOekdFroXTQ==}
+  '@effect/platform-node-shared@0.42.11':
+    resolution: {integrity: sha512-BQWTUtvFkqIW6GErxPXd++FQrF0Ujea3QJ0I+d5vrz6ZYc+mHBRqGsoyx2SzfjCGHL4rSLMDnCvGFFlUtpKfhA==}
     peerDependencies:
-      '@effect/cluster': ^0.41.10
-      '@effect/platform': ^0.87.6
-      '@effect/rpc': ^0.64.7
-      '@effect/sql': ^0.40.7
+      '@effect/cluster': ^0.41.11
+      '@effect/platform': ^0.87.7
+      '@effect/rpc': ^0.64.8
+      '@effect/sql': ^0.40.8
       effect: ^3.16.12
 
-  '@effect/platform-node@0.88.10':
-    resolution: {integrity: sha512-z5T+VZK7dLIm0iXSkBzXmXfVYWLppSxeiTi0c7/qFO2lOduafXP69JuWPbtY1La1jAZ4JvlGnUt9ruSAY1Y8yw==}
+  '@effect/platform-node@0.88.11':
+    resolution: {integrity: sha512-YJ/RkAyTT9Jo2WVmScr6AZIwdpeaqBvDZwH5XM7njHlh8xz98Tb/zbrkFILqsiedw0PinTmS4p0+q1tECS6maQ==}
     peerDependencies:
-      '@effect/cluster': ^0.41.10
-      '@effect/platform': ^0.87.6
-      '@effect/rpc': ^0.64.7
-      '@effect/sql': ^0.40.7
+      '@effect/cluster': ^0.41.11
+      '@effect/platform': ^0.87.7
+      '@effect/rpc': ^0.64.8
+      '@effect/sql': ^0.40.8
       effect: ^3.16.12
 
-  '@effect/platform@0.87.6':
-    resolution: {integrity: sha512-Q17LB7wEq9nSpzcxWk9MY8eYeeO8L5M7jgtL0r2V/TyptK2FUK+Z4audmldR53UHy46fCx/q8o9AADDMhyaJxA==}
+  '@effect/platform@0.87.7':
+    resolution: {integrity: sha512-pgn8DQD/MxWSzfdQhCpLcbrt5esCqYKNUIQgBYMdti4a3wOnLEVZw7y86Pe/pdOLxx1cyuVaJOp694xPIXaeFA==}
     peerDependencies:
       effect: ^3.16.12
 
-  '@effect/rpc@0.64.7':
-    resolution: {integrity: sha512-UkM26Ze1Trjrl/HxB7/e87vDx34vxA66clB1K7vWUuSpfoBZjQ/Cdky3z2xu5l6K0R7iz4rvsy3nrnm8ozwfZA==}
+  '@effect/rpc@0.64.8':
+    resolution: {integrity: sha512-6jPFq8z97b7B87/Gqo+DQ8qY9faaBBHcX93p9Z1qCj5bf/1ubaHdtPi+ZYt5pWYCNemJAaEQ81Vokkp8HZOUKg==}
     peerDependencies:
-      '@effect/platform': ^0.87.6
+      '@effect/platform': ^0.87.7
       effect: ^3.16.12
 
-  '@effect/sql@0.40.7':
-    resolution: {integrity: sha512-A1CxZfjGl4S65zc/kb1dR1n7fSk5bM2xwsxD0dSuBKKcFd8ipfXBMh35pXQbxKhLfRRCJsHHrtstpPRe72t5ow==}
+  '@effect/sql@0.40.8':
+    resolution: {integrity: sha512-WwAnkcoCNFZ+h/i5pDDdR3OmRB3lBBipvQUBScjvYgMDFIkBGA5CRcV0nvQ7Uh/eHs9OKdGGIBMKxtGDcOmxMw==}
     peerDependencies:
-      '@effect/experimental': ^0.51.7
-      '@effect/platform': ^0.87.6
+      '@effect/experimental': ^0.51.8
+      '@effect/platform': ^0.87.7
       effect: ^3.16.12
 
   '@effect/vitest@0.23.12':
@@ -257,11 +235,11 @@ packages:
       effect: ^3.16.12
       vitest: ^3.0.0
 
-  '@effect/workflow@0.4.7':
-    resolution: {integrity: sha512-nniO1WlZktuz/zYrefaB0WhKWqnRwqzAz/9o0+U6FtpcBjgtUlm7f4Dn26XElzQPz5Atfu+FZ23twl360SY7EQ==}
+  '@effect/workflow@0.4.8':
+    resolution: {integrity: sha512-iwBIp/cyv/c6vAmu0OTD6o4HOtaHKb/c6nWQQHA7zI0KQScC3ptFd4/yHAhKaiZ6sQR4pFqL6Cz+L7VmzAXwrw==}
     peerDependencies:
-      '@effect/platform': ^0.87.6
-      '@effect/rpc': ^0.64.7
+      '@effect/platform': ^0.87.7
+      '@effect/rpc': ^0.64.8
       effect: ^3.16.12
 
   '@esbuild/aix-ppc64@0.25.5':
@@ -551,103 +529,103 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
-  '@rollup/rollup-android-arm-eabi@4.44.1':
-    resolution: {integrity: sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==}
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.44.1':
-    resolution: {integrity: sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==}
+  '@rollup/rollup-android-arm64@4.44.2':
+    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.44.1':
-    resolution: {integrity: sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==}
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.44.1':
-    resolution: {integrity: sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==}
+  '@rollup/rollup-darwin-x64@4.44.2':
+    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.44.1':
-    resolution: {integrity: sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==}
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.44.1':
-    resolution: {integrity: sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==}
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.1':
-    resolution: {integrity: sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.1':
-    resolution: {integrity: sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.1':
-    resolution: {integrity: sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.44.1':
-    resolution: {integrity: sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==}
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.1':
-    resolution: {integrity: sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.1':
-    resolution: {integrity: sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.1':
-    resolution: {integrity: sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.1':
-    resolution: {integrity: sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==}
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.1':
-    resolution: {integrity: sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==}
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.44.1':
-    resolution: {integrity: sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==}
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.44.1':
-    resolution: {integrity: sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==}
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.1':
-    resolution: {integrity: sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==}
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.1':
-    resolution: {integrity: sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==}
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.44.1':
-    resolution: {integrity: sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==}
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
     cpu: [x64]
     os: [win32]
 
@@ -855,9 +833,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1059,15 +1034,12 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.44.1:
-    resolution: {integrity: sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==}
+  rollup@4.44.2:
+    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1161,11 +1133,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  tsx@4.20.3:
-    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -1463,26 +1430,26 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
+  '@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.87.6(effect@3.16.12)
-      '@effect/rpc': 0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
-      '@effect/sql': 0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
-      '@effect/workflow': 0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
+      '@effect/rpc': 0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
+      '@effect/workflow': 0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
       effect: 3.16.12
 
-  '@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)':
+  '@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.87.6(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
       effect: 3.16.12
       uuid: 11.1.0
 
-  '@effect/platform-node-shared@0.42.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
+  '@effect/platform-node-shared@0.42.11(@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/cluster': 0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
-      '@effect/platform': 0.87.6(effect@3.16.12)
-      '@effect/rpc': 0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
-      '@effect/sql': 0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
+      '@effect/cluster': 0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
+      '@effect/rpc': 0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
       '@parcel/watcher': 2.5.1
       effect: 3.16.12
       multipasta: 0.2.5
@@ -1491,13 +1458,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.88.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
+  '@effect/platform-node@0.88.11(@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/cluster': 0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
-      '@effect/platform': 0.87.6(effect@3.16.12)
-      '@effect/platform-node-shared': 0.42.10(@effect/cluster@0.41.10(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
-      '@effect/rpc': 0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
-      '@effect/sql': 0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
+      '@effect/cluster': 0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
+      '@effect/platform-node-shared': 0.42.11(@effect/cluster@0.41.11(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)
+      '@effect/rpc': 0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
+      '@effect/sql': 0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
       effect: 3.16.12
       mime: 3.0.0
       undici: 7.11.0
@@ -1506,35 +1473,35 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.87.6(effect@3.16.12)':
+  '@effect/platform@0.87.7(effect@3.16.12)':
     dependencies:
       effect: 3.16.12
       find-my-way-ts: 0.1.5
       msgpackr: 1.11.4
       multipasta: 0.2.5
 
-  '@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)':
+  '@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.87.6(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
       effect: 3.16.12
 
-  '@effect/sql@0.40.7(@effect/experimental@0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)':
+  '@effect/sql@0.40.8(@effect/experimental@0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/experimental': 0.51.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
-      '@effect/platform': 0.87.6(effect@3.16.12)
+      '@effect/experimental': 0.51.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
       '@opentelemetry/semantic-conventions': 1.34.0
       effect: 3.16.12
       uuid: 11.1.0
 
-  '@effect/vitest@0.23.12(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0)(tsx@4.20.3))':
+  '@effect/vitest@0.23.12(effect@3.16.12)(vitest@3.2.4(@types/node@22.16.0))':
     dependencies:
       effect: 3.16.12
-      vitest: 3.2.4(@types/node@22.16.0)(tsx@4.20.3)
+      vitest: 3.2.4(@types/node@22.16.0)
 
-  '@effect/workflow@0.4.7(@effect/platform@0.87.6(effect@3.16.12))(@effect/rpc@0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
+  '@effect/workflow@0.4.8(@effect/platform@0.87.7(effect@3.16.12))(@effect/rpc@0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12))(effect@3.16.12)':
     dependencies:
-      '@effect/platform': 0.87.6(effect@3.16.12)
-      '@effect/rpc': 0.64.7(@effect/platform@0.87.6(effect@3.16.12))(effect@3.16.12)
+      '@effect/platform': 0.87.7(effect@3.16.12)
+      '@effect/rpc': 0.64.8(@effect/platform@0.87.7(effect@3.16.12))(effect@3.16.12)
       effect: 3.16.12
 
   '@esbuild/aix-ppc64@0.25.5':
@@ -1722,64 +1689,64 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
 
-  '@rollup/rollup-android-arm-eabi@4.44.1':
+  '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.44.1':
+  '@rollup/rollup-android-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.44.1':
+  '@rollup/rollup-darwin-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.44.1':
+  '@rollup/rollup-darwin-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.44.1':
+  '@rollup/rollup-freebsd-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.44.1':
+  '@rollup/rollup-freebsd-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.1':
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.44.1':
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.1':
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.1':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.1':
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.1':
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.44.1':
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.44.1':
+  '@rollup/rollup-linux-x64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.1':
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.1':
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.44.1':
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
 
   '@standard-schema/spec@1.0.0': {}
@@ -1806,13 +1773,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@22.16.0)(tsx@4.20.3))':
+  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@22.16.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.2(@types/node@22.16.0)(tsx@4.20.3)
+      vite: 7.0.2(@types/node@22.16.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2001,10 +1968,6 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2172,34 +2135,32 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
   reusify@1.1.0: {}
 
-  rollup@4.44.1:
+  rollup@4.44.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.44.1
-      '@rollup/rollup-android-arm64': 4.44.1
-      '@rollup/rollup-darwin-arm64': 4.44.1
-      '@rollup/rollup-darwin-x64': 4.44.1
-      '@rollup/rollup-freebsd-arm64': 4.44.1
-      '@rollup/rollup-freebsd-x64': 4.44.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.44.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.44.1
-      '@rollup/rollup-linux-arm64-gnu': 4.44.1
-      '@rollup/rollup-linux-arm64-musl': 4.44.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.44.1
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.44.1
-      '@rollup/rollup-linux-riscv64-musl': 4.44.1
-      '@rollup/rollup-linux-s390x-gnu': 4.44.1
-      '@rollup/rollup-linux-x64-gnu': 4.44.1
-      '@rollup/rollup-linux-x64-musl': 4.44.1
-      '@rollup/rollup-win32-arm64-msvc': 4.44.1
-      '@rollup/rollup-win32-ia32-msvc': 4.44.1
-      '@rollup/rollup-win32-x64-msvc': 4.44.1
+      '@rollup/rollup-android-arm-eabi': 4.44.2
+      '@rollup/rollup-android-arm64': 4.44.2
+      '@rollup/rollup-darwin-arm64': 4.44.2
+      '@rollup/rollup-darwin-x64': 4.44.2
+      '@rollup/rollup-freebsd-arm64': 4.44.2
+      '@rollup/rollup-freebsd-x64': 4.44.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
+      '@rollup/rollup-linux-arm64-gnu': 4.44.2
+      '@rollup/rollup-linux-arm64-musl': 4.44.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-musl': 4.44.2
+      '@rollup/rollup-linux-s390x-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-musl': 4.44.2
+      '@rollup/rollup-win32-arm64-msvc': 4.44.2
+      '@rollup/rollup-win32-ia32-msvc': 4.44.2
+      '@rollup/rollup-win32-x64-msvc': 4.44.2
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -2270,13 +2231,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tsx@4.20.3:
-    dependencies:
-      esbuild: 0.25.5
-      get-tsconfig: 4.10.1
-    optionalDependencies:
-      fsevents: 2.3.3
-
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
@@ -2287,13 +2241,13 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  vite-node@3.2.4(@types/node@22.16.0)(tsx@4.20.3):
+  vite-node@3.2.4(@types/node@22.16.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.2(@types/node@22.16.0)(tsx@4.20.3)
+      vite: 7.0.2(@types/node@22.16.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2308,24 +2262,23 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.0.2(@types/node@22.16.0)(tsx@4.20.3):
+  vite@7.0.2(@types/node@22.16.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.1
+      rollup: 4.44.2
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.16.0
       fsevents: 2.3.3
-      tsx: 4.20.3
 
-  vitest@3.2.4(@types/node@22.16.0)(tsx@4.20.3):
+  vitest@3.2.4(@types/node@22.16.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@22.16.0)(tsx@4.20.3))
+      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@22.16.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2343,8 +2296,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.2(@types/node@22.16.0)(tsx@4.20.3)
-      vite-node: 3.2.4(@types/node@22.16.0)(tsx@4.20.3)
+      vite: 7.0.2(@types/node@22.16.0)
+      vite-node: 3.2.4(@types/node@22.16.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.16.0


### PR DESCRIPTION
## Summary

This PR introduces significant architectural improvements to the codebase:

- **Monorepo Structure**: Migrated to a monorepo architecture with separate packages for better modularity
- **Effect Layers**: Refactored services to use Effect's layer pattern for improved dependency injection and testability
- **HTTP Recording**: Added comprehensive HTTP request/response recording capabilities with configurable redaction support

## Changes

### 🏗️ Architecture
- Converted project to monorepo structure with `packages/` directory
- Implemented Effect layers for dependency injection
- Separated domain models, services, and infrastructure concerns

### 📦 Packages

#### `@effect/github`
- Refactored all services to use Effect patterns
- Improved error handling with tagged errors
- Enhanced type safety throughout
- Added proper service dependencies via layers

#### `@effect/http-recorder` 
- New package for recording and replaying HTTP interactions
- Configurable redaction system for sensitive data
- Support for custom headers via Config
- Comprehensive test coverage
- Transaction-based recording with unique IDs

### 🔧 Infrastructure
- Added GitHub Actions workflows for CI/CD
- Configured Changesets for version management
- Set up automated releases
- Added proper TypeScript project references

### 📚 Documentation
- Added comprehensive README for the monorepo
- Included setup guide for contributors
- Added JSDoc comments throughout the codebase

### 🧪 Testing
- Added extensive unit tests for HTTP recorder
- Configured Vitest for testing
- Added test sanitizers for schemas

## Breaking Changes

- Package imports now require scoped names (e.g., `@effect/github` instead of direct imports)
- Service instantiation now uses Effect layers instead of direct construction
- Error types have been restructured as tagged errors

## Migration Guide

```typescript
// Before
import { GitHubService } from 'github-sdk'
const service = new GitHubService(config)

// After
import { GitHubService, GitHubServiceLive } from '@effect/github'
const program = Effect.gen(function* () {
  const service = yield* GitHubService
  // use service
}).pipe(
  Effect.provide(GitHubServiceLive)
)
```

## Test Plan

- [x] All existing tests pass
- [x] New HTTP recorder tests provide comprehensive coverage
- [x] CI pipeline validates builds and tests
- [x] Package publishing workflow tested locally